### PR TITLE
feat(driverbase): add enumerator factory for GetObjects

### DIFF
--- a/driverbase/xdbc.go
+++ b/driverbase/xdbc.go
@@ -87,3 +87,7 @@ func NullInt32ToPtr(i sql.NullInt32) *int32 {
 	}
 	return &i.Int32
 }
+
+func ToPtr[T any](i T) *T {
+	return &i
+}


### PR DESCRIPTION
## What's Changed

This lets a driver create a separate object instance for a GetObjects call, allowing it to cache state more easily.
