### PR TITLE
chore: remove redundant notice from licenses

### DIFF
--- a/driverbase/LICENSE.txt
+++ b/driverbase/LICENSE.txt
@@ -205,8 +205,6 @@
 
 This project includes code from Apache Arrow ADBC.
 
-* driverbase/ contains code from ADBC.
-
 Copyright: 2022 The Apache Software Foundation.
 Home page: https://arrow.apache.org/adbc/
 License: http://www.apache.org/licenses/LICENSE-2.0

--- a/sqlwrapper/LICENSE.txt
+++ b/sqlwrapper/LICENSE.txt
@@ -200,13 +200,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
---------------------------------------------------------------------------------
-
-This project includes code from Apache Arrow ADBC.
-
-* driverbase/ contains code from ADBC.
-
-Copyright: 2022 The Apache Software Foundation.
-Home page: https://arrow.apache.org/adbc/
-License: http://www.apache.org/licenses/LICENSE-2.0

--- a/testutil/LICENSE.txt
+++ b/testutil/LICENSE.txt
@@ -200,13 +200,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
---------------------------------------------------------------------------------
-
-This project includes code from Apache Arrow ADBC.
-
-* driverbase/ contains code from ADBC.
-
-Copyright: 2022 The Apache Software Foundation.
-Home page: https://arrow.apache.org/adbc/
-License: http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## What's Changed

Remove "this project includes code from Apache Arrow ADBC" notice from places where it doesn't belong.
