### PR TITLE
feat(driverbase): make it easier to bulk register info codes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,12 @@ repos:
     types_or: [go, go-mod]
 
   - id: golangci-lint
+    name: lint driverbase (assert)
+    entry: bash -c 'cd driverbase && golangci-lint run --build-tags=assert --fix --timeout 5m'
+    files: ^driverbase/
+    types_or: [go, go-mod]
+
+  - id: golangci-lint
     name: lint testutil
     entry: bash -c 'cd testutil && golangci-lint run --fix --timeout 5m'
     files: ^testutil/

--- a/driverbase/bulk_ingest.go
+++ b/driverbase/bulk_ingest.go
@@ -99,6 +99,17 @@ func (options *BulkIngestOptions) SetOption(eh *ErrorHelper, key, val string) (b
 		default:
 			return true, eh.Errorf(adbc.StatusInvalidArgument, "invalid statement option %s=%s", key, val)
 		}
+	case adbc.OptionValueIngestTemporary:
+		switch val {
+		case adbc.OptionValueEnabled:
+			options.Temporary = true
+			options.SchemaName = ""
+			options.CatalogName = ""
+		case adbc.OptionValueDisabled:
+			options.Temporary = false
+		default:
+			return true, eh.Errorf(adbc.StatusInvalidArgument, "invalid statement option %s=%s", key, val)
+		}
 	default:
 		return false, nil
 	}

--- a/driverbase/driver_info.go
+++ b/driverbase/driver_info.go
@@ -152,6 +152,14 @@ func (di *DriverInfo) RegisterInfoCode(code adbc.InfoCode, value any) error {
 	return err
 }
 
+func (di *DriverInfo) MustRegister(codes map[adbc.InfoCode]any) {
+	for code, value := range codes {
+		if err := di.RegisterInfoCode(code, value); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func (di *DriverInfo) GetInfoForInfoCode(code adbc.InfoCode) (any, bool) {
 	val, ok := di.info[code]
 	return val, ok

--- a/driverbase/shared.go
+++ b/driverbase/shared.go
@@ -15,7 +15,6 @@
 package driverbase
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -35,25 +34,6 @@ func NewShared[T any](handle *T, closer io.Closer) *Shared[T] {
 		handle: handle,
 		closer: closer,
 	}
-}
-
-func (sh *Shared[T]) Close() error {
-	sh.mu.Lock()
-	defer sh.mu.Unlock()
-
-	if sh.handle == nil {
-		return nil
-	}
-
-	if err := sh.closer.Close(); err != nil {
-		return errors.Join(adbc.Error{
-			Code: adbc.StatusInternal,
-			Msg:  fmt.Sprintf("[driverbase] Shared[%T].Close: failed to close resource: %s", *new(T), err),
-		}, err)
-	}
-	sh.handle = nil
-	sh.closer = nil
-	return nil
 }
 
 // Hold gets exclusive access to the connection until the returned handle is released.

--- a/driverbase/shared_assert.go
+++ b/driverbase/shared_assert.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build assert
+
+package driverbase
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+)
+
+func (sh *Shared[T]) Close() error {
+	if !sh.mu.TryLock() {
+		return adbc.Error{
+			Code: adbc.StatusInvalidState,
+			Msg:  fmt.Sprintf("[driverbase] Shared[%T].Close: resource is currently in use", *new(T)),
+		}
+	}
+	defer sh.mu.Unlock()
+
+	if sh.handle == nil {
+		return nil
+	}
+
+	if err := sh.closer.Close(); err != nil {
+		return errors.Join(adbc.Error{
+			Code: adbc.StatusInternal,
+			Msg:  fmt.Sprintf("[driverbase] Shared[%T].Close: failed to close resource: %s", *new(T), err),
+		}, err)
+	}
+	sh.handle = nil
+	sh.closer = nil
+	return nil
+}

--- a/driverbase/shared_noassert.go
+++ b/driverbase/shared_noassert.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !assert
+
+package driverbase
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+)
+
+func (sh *Shared[T]) Close() error {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+
+	if sh.handle == nil {
+		return nil
+	}
+
+	if err := sh.closer.Close(); err != nil {
+		return errors.Join(adbc.Error{
+			Code: adbc.StatusInternal,
+			Msg:  fmt.Sprintf("[driverbase] Shared[%T].Close: failed to close resource: %s", *new(T), err),
+		}, err)
+	}
+	sh.handle = nil
+	sh.closer = nil
+	return nil
+}


### PR DESCRIPTION
## What's Changed

- Run golangci-lint for code that only builds with `assert` tag
- Add `MustRegister`
- Check for deadlock in `Shared.Close`
