### PR TITLE
fix(sqlwrapper): handle record readers not being drained

### DIFF
--- a/sqlwrapper/record_reader.go
+++ b/sqlwrapper/record_reader.go
@@ -132,7 +132,6 @@ type sqlRecordReaderImpl struct {
 // For SQL queries with bind parameters, this method executes the query with the
 // specific parameter set (rec[rowIdx]) and returns the resulting schema.
 func (s *sqlRecordReaderImpl) NextResultSet(ctx context.Context, rec arrow.RecordBatch, rowIdx int) (schema *arrow.Schema, err error) {
-
 	// Close any previous result set
 	if s.rows != nil {
 		if err := s.rows.Close(); err != nil {


### PR DESCRIPTION
## What's Changed

Track result sets, and close the previous result set when a new one is opened.

Closes #53.
