### PR TITLE
fix(sqlwrapper): avoid automatic UTC timezone on timestamp and datetime

### DIFF
--- a/sqlwrapper/typeconverter.go
+++ b/sqlwrapper/typeconverter.go
@@ -380,7 +380,8 @@ func (d DefaultTypeConverter) ConvertRawColumnType(colType ColumnType) (arrow.Da
 			timestampType = &arrow.TimestampType{Unit: timeUnit}
 		} else {
 			// No precision info available, default to microseconds (most common)
-			timestampType = arrow.FixedWidthTypes.Timestamp_us
+			// Use manual TimestampType creation to avoid automatic UTC timezone
+			timestampType = &arrow.TimestampType{Unit: arrow.Microsecond}
 		}
 
 		metadata := arrow.MetadataFrom(metadataMap)


### PR DESCRIPTION
## What's Changed

arrow.FixedWidthTypes.Timestamp_us has UTC timezone by default. Now uses manual TimestampType creation to avoid automatic UTC timezone
