### PR TITLE
fix(sqlwrapper): prevent double release on error

### DIFF
--- a/sqlwrapper/statement.go
+++ b/sqlwrapper/statement.go
@@ -279,6 +279,8 @@ func (s *statementImpl) ExecuteQuery(ctx context.Context) (reader array.RecordRe
 	// not in a way that breaks the connection!
 	if err := baseRecordReader.Init(context.Background(), memory.DefaultAllocator, s.boundStream,
 		int64(s.batchSize), impl); err != nil {
+		// Clear boundStream on error to prevent double-release in Close()
+		s.boundStream = nil
 		return nil, -1, s.Base().ErrorHelper.IO("failed to create record reader: %v", err)
 	}
 	s.boundStream = nil


### PR DESCRIPTION
## What's Changed

Clear boundStream on error to prevent double-release in Close()
