### PR TITLE
feat(validation): Fixed error code check

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -1332,7 +1332,7 @@ func (s *StatementTests) TestSqlIngestErrors() {
 		var e adbc.Error
 		_, err = stmt.ExecuteUpdate(s.ctx)
 		s.ErrorAs(err, &e)
-		s.Equal(adbc.StatusInternal, e.Code)
+		s.Equal(adbc.StatusAlreadyExists, e.Code)
 
 		// try to append an incompatible schema
 		schema, _ = schema.AddField(1, arrow.Field{Name: "coltwo", Type: arrow.PrimitiveTypes.Int64, Nullable: true})


### PR DESCRIPTION
## What's Changed

When the table is created for the second time, the correct error is StatusAlreadyExists.