### PR TITLE
fix(sqlwrapper): allow ExecuteQuery to handle bulk ingest

### DIFF
--- a/sqlwrapper/statement.go
+++ b/sqlwrapper/statement.go
@@ -113,7 +113,7 @@ func (s *statementImpl) SetSqlQuery(query string) error {
 	}
 
 	// Setting a SQL query switches out of bulk ingest mode
-	s.bulkIngestOptions = driverbase.NewBulkIngestOptions()
+	s.bulkIngestOptions.Clear()
 
 	s.query = query
 	return nil


### PR DESCRIPTION
## What's Changed

The driver should be able to handle bulk ingest both from ExecuteQuery. 

This should close https://github.com/adbc-drivers/driverbase-go/pull/124