### PR TITLE
feat(driverbase): add support for manual cancellation

### DIFF
--- a/sqlwrapper/statement.go
+++ b/sqlwrapper/statement.go
@@ -298,7 +298,7 @@ func (s *statementImpl) ExecuteQuery(ctx context.Context) (reader array.RecordRe
 	options := driverbase.BaseRecordReaderOptions{
 		BatchRowLimit: int64(s.batchSize),
 	}
-	if err := baseRecordReader.Init(context.Background(), memory.DefaultAllocator, s.boundStream,
+	if err := baseRecordReader.Init(context.Background(), memory.DefaultAllocator, s.stmt.Logger, s.boundStream,
 		options, impl); err != nil {
 		// Clear boundStream on error to prevent double-release in Close()
 		s.boundStream = nil


### PR DESCRIPTION
For some databases/client libraries, we need to manually call a cancel function; let the driverbase handle it so we don't have to deal with concurrent calls.