### PR TITLE
fix(driverbase): call DatabaseImpl.Close in database.Close

### DIFF
--- a/driverbase/database.go
+++ b/driverbase/database.go
@@ -168,7 +168,9 @@ func (base *DatabaseImplBase) SetOptionInt(ctx context.Context, key string, val 
 }
 
 func (base *database) Close(ctx context.Context) error {
-	return base.Base().Close(ctx)
+	implErr := base.DatabaseImpl.Close(ctx)
+	baseErr := base.Base().Close(ctx)
+	return errors.Join(implErr, baseErr)
 }
 
 func (base *DatabaseImplBase) Close(ctx context.Context) (err error) {


### PR DESCRIPTION
## Summary

- `database.Close()` was only calling `base.Base().Close()`, which delegates to `DatabaseImplBase.Close()` — performing tracer shutdown only
- The implementation's own `Close()` was never invoked, so resources owned by the impl (e.g. a `*sql.DB` connection pool) were never released
- Fix: call `base.DatabaseImpl.Close(ctx)` first, then `base.Base().Close(ctx)` for framework-level cleanup

## Root cause

```go
// Before: only tracer shutdown, impl.Close() never called
func (base *database) Close(ctx context.Context) error {
    return base.Base().Close(ctx)
}
```

`base.Base()` returns `*DatabaseImplBase`. Calling `Close()` on that static type always resolves to `DatabaseImplBase.Close()` regardless of the concrete impl type — Go has no virtual dispatch. Any `Close()` override defined on the impl struct is therefore unreachable via this path.

```go
// After: impl resources released, then framework cleanup
func (base *database) Close(ctx context.Context) error {
    implErr := base.DatabaseImpl.Close(ctx)
    baseErr := base.Base().Close(ctx)
    return errors.Join(implErr, baseErr)
}
```

When no impl override of `Close()` exists, `base.DatabaseImpl.Close(ctx)` promotes to `DatabaseImplBase.Close()`, which is then called again by `base.Base().Close(ctx)`. This is safe: `tracerShutdownFunc` is set to `nil` after the first call, making the second a no-op.

## Test plan

- [x] Existing driverbase unit tests pass (`go test ./...`)
- [x] Verified that `sqlwrapper.databaseImpl.Close()` (which calls `sql.DB.Close()`) is now invoked when `db.Close()` is called on an ADBC database

🤖 Generated with [Claude Code](https://claude.com/claude-code)