### PR TITLE
feat(driverbase): add common retry utility

### DIFF
--- a/driverbase/gadgets/backoff.go
+++ b/driverbase/gadgets/backoff.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gadgets
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"math/rand/v2"
+	"time"
+)
+
+// Backoff computes a retry interval with random jitter, similar to
+// gax.Backoff.
+type Backoff struct {
+	Start time.Duration
+	Max   time.Duration
+	Mul   float64
+
+	currentMax time.Duration
+}
+
+func (b *Backoff) Next() time.Duration {
+	// Defaults chosen somewhat arbitrarily
+	if b.Max == 0 {
+		b.Max = 10 * time.Second
+	}
+	if b.Start == 0 {
+		b.Start = time.Second
+	}
+	if b.Start > b.Max {
+		b.Start = b.Max
+	}
+	if b.currentMax == 0 {
+		b.currentMax = b.Start
+	}
+	if b.Mul == 0 {
+		b.Mul = 1.5
+	}
+
+	// Random duration between 1ns and nextBackoff
+	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+	backoff := time.Duration(rand.Int64N(1 + int64(b.currentMax)))
+	b.currentMax = min(time.Duration(float64(b.currentMax)*b.Mul), b.Max)
+	return backoff
+}
+
+func RetryWithLog(ctx context.Context, logger *slog.Logger, operation string, b *Backoff, maxTries int, op func() error) error {
+	if maxTries == 0 {
+		return errors.New("driverbase.gadgets.Retry: maxTries must be > 0")
+	} else if b == nil {
+		b = &Backoff{}
+	}
+	var err error
+	for range maxTries {
+		err = op()
+		if err == nil {
+			return nil
+		} else if errors.Is(err, errNoRetry) {
+			if logger != nil {
+				logger.DebugContext(ctx, "no retry: "+operation, "error", err)
+			}
+			return err
+		}
+		pause := b.Next()
+		if logger != nil {
+			logger.DebugContext(ctx, "retrying: "+operation, "error", err, "backoff", pause)
+		}
+		time.Sleep(pause)
+	}
+	return err
+}
+
+func Retry(b *Backoff, maxTries int, op func() error) error {
+	return RetryWithLog(nil, nil, "", b, maxTries, op)
+}
+
+var errNoRetry = errors.New("operation failed and could not be retried")
+
+func NoRetry(err error) error {
+	return errors.Join(err, errNoRetry)
+}

--- a/driverbase/gadgets/backoff.go
+++ b/driverbase/gadgets/backoff.go
@@ -118,5 +118,8 @@ func Retry(b *Backoff, maxTries int, op func() error) error {
 var errNoRetry = errors.New("operation failed and could not be retried")
 
 func NoRetry(err error) error {
+	if err == nil {
+		return nil
+	}
 	return errors.Join(err, errNoRetry)
 }

--- a/driverbase/gadgets/backoff.go
+++ b/driverbase/gadgets/backoff.go
@@ -23,9 +23,13 @@ import (
 )
 
 func SleepCtx(ctx context.Context, duration time.Duration) error {
+	if ctx == nil {
+		time.Sleep(duration)
+		return nil
+	}
+
 	timer := time.NewTimer(duration)
 	defer timer.Stop()
-
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -71,7 +75,7 @@ func (b *Backoff) Next() time.Duration {
 
 func RetryWithLog(ctx context.Context, logger *slog.Logger, operation string, b *Backoff, maxTries int, op func() error) error {
 	if maxTries <= 0 {
-		return errors.New("driverbase.gadgets.Retry: maxTries must be > 0")
+		return errors.New("driverbase.gadgets.RetryWithLog: maxTries must be > 0")
 	}
 
 	if b == nil {

--- a/driverbase/gadgets/backoff.go
+++ b/driverbase/gadgets/backoff.go
@@ -22,6 +22,18 @@ import (
 	"time"
 )
 
+func SleepCtx(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 // Backoff computes a retry interval with random jitter, similar to
 // gax.Backoff.
 type Backoff struct {
@@ -34,37 +46,43 @@ type Backoff struct {
 
 func (b *Backoff) Next() time.Duration {
 	// Defaults chosen somewhat arbitrarily
-	if b.Max == 0 {
+	if b.Max <= 0 {
 		b.Max = 10 * time.Second
 	}
-	if b.Start == 0 {
+	if b.Start <= 0 {
 		b.Start = time.Second
 	}
 	if b.Start > b.Max {
 		b.Start = b.Max
 	}
-	if b.currentMax == 0 {
-		b.currentMax = b.Start
-	}
-	if b.Mul == 0 {
+	if b.Mul <= 0 {
 		b.Mul = 1.5
+	}
+	if b.currentMax <= 0 {
+		b.currentMax = b.Start
 	}
 
 	// Random duration between 1ns and nextBackoff
 	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
-	backoff := time.Duration(rand.Int64N(1 + int64(b.currentMax)))
+	backoff := time.Duration(max(int64(1), rand.Int64N(1+int64(b.currentMax))))
 	b.currentMax = min(time.Duration(float64(b.currentMax)*b.Mul), b.Max)
 	return backoff
 }
 
 func RetryWithLog(ctx context.Context, logger *slog.Logger, operation string, b *Backoff, maxTries int, op func() error) error {
-	if maxTries == 0 {
+	if maxTries <= 0 {
 		return errors.New("driverbase.gadgets.Retry: maxTries must be > 0")
-	} else if b == nil {
+	}
+
+	if b == nil {
 		b = &Backoff{}
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var err error
-	for range maxTries {
+	for i := range maxTries {
 		err = op()
 		if err == nil {
 			return nil
@@ -78,13 +96,19 @@ func RetryWithLog(ctx context.Context, logger *slog.Logger, operation string, b 
 		if logger != nil {
 			logger.DebugContext(ctx, "retrying: "+operation, "error", err, "backoff", pause)
 		}
-		time.Sleep(pause)
+		if i == maxTries-1 {
+			// Don't unnecessarily sleep on the last iteration
+			break
+		}
+		if err := SleepCtx(ctx, pause); err != nil {
+			return err
+		}
 	}
 	return err
 }
 
 func Retry(b *Backoff, maxTries int, op func() error) error {
-	return RetryWithLog(nil, nil, "", b, maxTries, op)
+	return RetryWithLog(context.Background(), nil, "", b, maxTries, op)
 }
 
 var errNoRetry = errors.New("operation failed and could not be retried")

--- a/driverbase/gadgets/backoff_test.go
+++ b/driverbase/gadgets/backoff_test.go
@@ -139,3 +139,23 @@ func TestRetryLog(t *testing.T) {
 	assert.Contains(t, log, "fail 4")
 	t.Log(log)
 }
+
+func TestRetryCancel(t *testing.T) {
+	counter := 0
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	err := gadgets.RetryWithLog(ctx, logger, "foobar", &gadgets.Backoff{}, 1000, func() error {
+		counter += 1
+		return fmt.Errorf("fail %d", counter)
+	})
+
+	assert.Less(t, counter, 1000)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/driverbase/gadgets/backoff_test.go
+++ b/driverbase/gadgets/backoff_test.go
@@ -152,6 +152,7 @@ func TestRetryCancel(t *testing.T) {
 		cancel()
 	}()
 	err := gadgets.RetryWithLog(ctx, logger, "foobar", &gadgets.Backoff{}, 1000, func() error {
+		time.Sleep(5 * time.Millisecond)
 		counter += 1
 		return fmt.Errorf("fail %d", counter)
 	})

--- a/driverbase/gadgets/backoff_test.go
+++ b/driverbase/gadgets/backoff_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gadgets_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/adbc-drivers/driverbase-go/driverbase/gadgets"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoffDefault(t *testing.T) {
+	b := &gadgets.Backoff{}
+	_ = b.Next()
+	assert.Equal(t, time.Second, b.Start)
+	assert.Equal(t, 10*time.Second, b.Max)
+	assert.Equal(t, 1.5, b.Mul)
+}
+
+func TestBackoff(t *testing.T) {
+	for _, maxBackoff := range []time.Duration{time.Second, 10 * time.Second, 30 * time.Second} {
+		t.Run(maxBackoff.String(), func(t *testing.T) {
+			b := &gadgets.Backoff{
+				Max: maxBackoff,
+			}
+			for range 200 {
+				backoff := b.Next()
+				assert.LessOrEqual(t, backoff, maxBackoff, "backoff %v exceeds max %v", backoff, maxBackoff)
+			}
+		})
+	}
+}
+
+func TestRetryInvalid(t *testing.T) {
+	err := gadgets.Retry(&gadgets.Backoff{}, 0, func() error {
+		return nil
+	})
+	assert.ErrorContains(t, err, "maxTries must be > 0")
+}
+
+func TestRetryNoRetries(t *testing.T) {
+	counter := 0
+	err := gadgets.Retry(&gadgets.Backoff{}, 1, func() error {
+		counter += 1
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, counter)
+}
+
+func TestRetryDefault(t *testing.T) {
+	counter := 0
+	// no need to pass backoff explicitly
+	err := gadgets.Retry(nil, 2, func() error {
+		counter += 1
+		if counter == 1 {
+			return errors.New("fail")
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, counter)
+}
+
+func TestRetryExhausted(t *testing.T) {
+	counter := 0
+	err := gadgets.Retry(&gadgets.Backoff{Max: time.Millisecond}, 4, func() error {
+		counter += 1
+		return fmt.Errorf("fail %d", counter)
+	})
+	assert.Equal(t, 4, counter)
+	assert.ErrorContains(t, err, "fail 4")
+}
+
+func TestRetryEventual(t *testing.T) {
+	counter := 0
+	err := gadgets.Retry(&gadgets.Backoff{Max: time.Millisecond}, 10, func() error {
+		counter += 1
+		if counter < 5 {
+			return fmt.Errorf("fail %d", counter)
+		}
+		return nil
+	})
+	assert.Equal(t, 5, counter)
+	assert.NoError(t, err)
+}
+
+func TestRetryAborted(t *testing.T) {
+	counter := 0
+	err := gadgets.Retry(&gadgets.Backoff{Max: time.Millisecond}, 10, func() error {
+		counter += 1
+		if counter < 5 {
+			return fmt.Errorf("fail %d", counter)
+		}
+		return gadgets.NoRetry(fmt.Errorf("fail %d", counter))
+	})
+	assert.Equal(t, 5, counter)
+	assert.ErrorContains(t, err, "fail 5")
+	assert.ErrorContains(t, err, "operation failed and could not be retried")
+}
+
+func TestRetryLog(t *testing.T) {
+	counter := 0
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	err := gadgets.RetryWithLog(context.Background(), logger, "foobar", &gadgets.Backoff{Max: time.Millisecond}, 10, func() error {
+		counter += 1
+		if counter < 5 {
+			return fmt.Errorf("fail %d", counter)
+		}
+		return nil
+	})
+	assert.Equal(t, 5, counter)
+	assert.NoError(t, err)
+
+	log := buf.String()
+	assert.Contains(t, log, "retrying: foobar")
+	assert.Contains(t, log, "fail 1")
+	assert.Contains(t, log, "fail 4")
+	t.Log(log)
+}


### PR DESCRIPTION
Basically what something like gax.Backoff provides, but not tied to a vendor's SDK.