### PR TITLE
fix(driverbase): disable Parquet stats by default for bulk ingest

### DIFF
--- a/driverbase/bulk_ingest.go
+++ b/driverbase/bulk_ingest.go
@@ -93,10 +93,13 @@ func NewBulkIngestOptions() BulkIngestOptions {
 		MaxPendingBuffers:   2,
 		UploaderParallelism: 2,
 		WriterProps: WriterProps{
-			MaxBytes:           64 * 1024 * 1024, // 64MiB
-			ParquetWriterProps: parquet.NewWriterProperties(parquet.WithCompression(compress.Codecs.Snappy)),
-			ArrowWriterProps:   pqarrow.NewArrowWriterProperties(),
-			ArrowIpcProps:      []ipc.Option{ipc.WithZstd()},
+			MaxBytes: 64 * 1024 * 1024, // 64MiB
+			ParquetWriterProps: parquet.NewWriterProperties(
+				parquet.WithCompression(compress.Codecs.Snappy),
+				parquet.WithStats(false),
+			),
+			ArrowWriterProps: pqarrow.NewArrowWriterProperties(),
+			ArrowIpcProps:    []ipc.Option{ipc.WithZstd()},
 		},
 	}
 }


### PR DESCRIPTION
For https://github.com/adbc-drivers/bigquery/issues/229
