### PR TITLE
feat(sqlwrapper): added transactions and isolation levels support

### DIFF
--- a/sqlwrapper/connection.go
+++ b/sqlwrapper/connection.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/adbc-drivers/driverbase-go/driverbase"
@@ -46,7 +47,68 @@ type ConnectionImplBase struct {
 	// db is the underlying database for metadata operations
 	Db *sql.DB
 
+	// tx is the active transaction, or nil when autocommit is on.
+	tx *sql.Tx
+	// isolationLevel is the last-set ADBC isolation level, applied to
+	// each BeginTx. LevelDefault means "use the server's default".
+	isolationLevel adbc.OptionIsolationLevel
+
 	Pending io.Closer
+}
+
+// adbcToSqlIsolationLevel maps ADBC OptionIsolationLevel values to the
+// standard library's sql.IsolationLevel. All known ADBC levels are mapped;
+// only unknown strings produce an error. The underlying database/sql driver
+// decides at BeginTx time whether a given level is actually supported.
+func adbcToSqlIsolationLevel(level adbc.OptionIsolationLevel) (sql.IsolationLevel, error) {
+	switch level {
+	case adbc.LevelDefault:
+		return sql.LevelDefault, nil
+	case adbc.LevelReadUncommitted:
+		return sql.LevelReadUncommitted, nil
+	case adbc.LevelReadCommitted:
+		return sql.LevelReadCommitted, nil
+	case adbc.LevelRepeatableRead:
+		return sql.LevelRepeatableRead, nil
+	case adbc.LevelSnapshot:
+		return sql.LevelSnapshot, nil
+	case adbc.LevelSerializable:
+		return sql.LevelSerializable, nil
+	case adbc.LevelLinearizable:
+		return sql.LevelLinearizable, nil
+	default:
+		return sql.LevelDefault, adbc.Error{
+			Code: adbc.StatusInvalidArgument,
+			Msg:  fmt.Sprintf("unknown isolation level %q", string(level)),
+		}
+	}
+}
+
+// beginNewTx starts a new transaction on the dedicated connection, applying
+// the cached isolation level (if any). The resulting *sql.Tx is stored on
+// both the ConnectionImplBase and the LoggingConn so that all subsequent
+// statement execution routes through the transaction.
+//
+// The transaction is started with a context derived from the caller's context
+// via context.WithoutCancel so that it survives across CGO driver-manager
+// calls, each of which creates and cancels its own context. The tx lives
+// until explicitly committed or rolled back via Commit/Rollback.
+func (c *ConnectionImplBase) beginNewTx(ctx context.Context) error {
+	opts := &sql.TxOptions{}
+	if c.isolationLevel != "" && c.isolationLevel != adbc.LevelDefault {
+		level, err := adbcToSqlIsolationLevel(c.isolationLevel)
+		if err != nil {
+			return err
+		}
+		opts.Isolation = level
+	}
+	tx, err := c.Conn.Conn.BeginTx(context.WithoutCancel(ctx), opts)
+	if err != nil {
+		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "BEGIN failed: %v", err)
+	}
+	c.tx = tx
+	c.Conn.Tx = tx
+	return nil
 }
 
 // newConnection creates a new ADBC Connection by acquiring a *sql.Conn from the pool.
@@ -114,37 +176,111 @@ func (c *ConnectionImplBase) NewStatement(ctx context.Context) (adbc.StatementWi
 	return newStatement(c)
 }
 
-// SetOption sets a string option on this connection
+// SetOption sets a string option on this connection.
+// Handles OptionKeyIsolationLevel by caching the level for the next BeginTx;
+// if a transaction is already active (autocommit was disabled before the
+// isolation level was set), it restarts the transaction with the new level
+// so that subsequent statements use the correct isolation.
+// All other keys are delegated to the embedded driverbase base.
 func (c *ConnectionImplBase) SetOption(ctx context.Context, key, value string) error {
-	return c.ConnectionImplBase.SetOption(ctx, key, value)
+	switch key {
+	case adbc.OptionKeyIsolationLevel:
+		level := adbc.OptionIsolationLevel(value)
+		if _, err := adbcToSqlIsolationLevel(level); err != nil {
+			return err
+		}
+		c.isolationLevel = level
+		// If a transaction is already active (e.g. SetAutocommit(false) was
+		// called before SetOption(isolation=...), as sqldriver.BeginTx does),
+		// restart it so the new isolation level takes effect. This is safe
+		// because no user statements have been executed yet when called via
+		// sqldriver.BeginTx (which sets autocommit first, then isolation,
+		// before returning the tx handle to the caller).
+		if c.tx != nil {
+			if err := c.tx.Rollback(); err != nil {
+				return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "ROLLBACK for isolation restart failed: %v", err)
+			}
+			c.tx = nil
+			c.Conn.Tx = nil
+			return c.beginNewTx(ctx)
+		}
+		return nil
+	default:
+		return c.ConnectionImplBase.SetOption(ctx, key, value)
+	}
 }
 
+// GetOption returns a string option value.
+// Handles OptionKeyIsolationLevel by returning the cached level.
 func (c *ConnectionImplBase) GetOption(ctx context.Context, key string) (string, error) {
-	return c.ConnectionImplBase.GetOption(ctx, key)
+	switch key {
+	case adbc.OptionKeyIsolationLevel:
+		return string(c.isolationLevel), nil
+	default:
+		return c.ConnectionImplBase.GetOption(ctx, key)
+	}
 }
 
-// Commit is a no-op under auto-commit mode
-// TODO (https://github.com/adbc-drivers/driverbase-go/issues/28): we'll likely want to utilize https://pkg.go.dev/database/sql#Tx
-// to manage this here
+// SetAutocommit implements driverbase.AutocommitSetter.
+// Disabling autocommit begins a transaction on the dedicated session
+// connection; enabling it commits any in-flight transaction and lets
+// subsequent statements auto-commit (the database/sql default).
+// The driverbase wrapper updates Base().Autocommit after a successful return.
+func (c *ConnectionImplBase) SetAutocommit(ctx context.Context, enabled bool) error {
+	if enabled {
+		if c.tx != nil {
+			if err := c.tx.Commit(); err != nil {
+				return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "COMMIT failed: %v", err)
+			}
+			c.tx = nil
+			c.Conn.Tx = nil
+		}
+		return nil
+	}
+	if c.tx == nil {
+		return c.beginNewTx(ctx)
+	}
+	return nil
+}
+
+// Commit commits the current transaction. After COMMIT a new transaction is
+// immediately begun (chained-transaction semantics) so the next statement
+// continues to run inside a transaction until the caller re-enables autocommit.
+// The driverbase wrapper short-circuits to StatusInvalidState when autocommit
+// is enabled, so this method is only reached when autocommit is disabled.
 func (c *ConnectionImplBase) Commit(ctx context.Context) error {
-	return c.Base().ErrorHelper.Errorf(
-		adbc.StatusNotImplemented,
-		"Commit not supported in auto-commit mode",
-	)
+	if c.tx == nil {
+		return c.Base().ErrorHelper.Errorf(adbc.StatusInvalidState, "no active transaction")
+	}
+	if err := c.tx.Commit(); err != nil {
+		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "COMMIT failed: %v", err)
+	}
+	return c.beginNewTx(ctx)
 }
 
-// Rollback is a no-op under auto-commit mode
-// TODO (https://github.com/adbc-drivers/driverbase-go/issues/28): we'll likely want to utilize https://pkg.go.dev/database/sql#Tx
-// to manage this here
+// Rollback rolls back the current transaction. Like Commit, it begins a new
+// transaction immediately afterwards (chained-transaction semantics).
+// The driverbase wrapper short-circuits to StatusInvalidState when autocommit
+// is enabled, so this method is only reached when autocommit is disabled.
 func (c *ConnectionImplBase) Rollback(ctx context.Context) error {
-	return c.Base().ErrorHelper.Errorf(
-		adbc.StatusNotImplemented,
-		"Rollback not supported in auto-commit mode",
-	)
+	if c.tx == nil {
+		return c.Base().ErrorHelper.Errorf(adbc.StatusInvalidState, "no active transaction")
+	}
+	if err := c.tx.Rollback(); err != nil {
+		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "ROLLBACK failed: %v", err)
+	}
+	return c.beginNewTx(ctx)
 }
 
-// Close closes the underlying SQL connection
+// Close closes the underlying SQL connection. If a transaction is active,
+// it is rolled back first to avoid leaving the connection in an inconsistent
+// state.
 func (c *ConnectionImplBase) Close(ctx context.Context) error {
+	if c.tx != nil {
+		_ = c.tx.Rollback()
+		c.tx = nil
+		c.Conn.Tx = nil
+	}
 	if err := c.ClearPending(); err != nil {
 		return errors.Join(err, c.Conn.Close())
 	}

--- a/sqlwrapper/connection.go
+++ b/sqlwrapper/connection.go
@@ -49,17 +49,17 @@ type ConnectionImplBase struct {
 
 	// tx is the active transaction, or nil when autocommit is on.
 	tx *sql.Tx
-	// isolationLevel is the last-set ADBC isolation level, applied to
-	// each BeginTx. LevelDefault means "use the server's default".
+	// txCancel releases the deadline goroutine from beginNewTx; nil if no deadline.
+	txCancel context.CancelFunc
+	// isolationLevel is the last-set ADBC isolation level, applied at BeginTx.
 	isolationLevel adbc.OptionIsolationLevel
 
 	Pending io.Closer
 }
 
-// adbcToSqlIsolationLevel maps ADBC OptionIsolationLevel values to the
-// standard library's sql.IsolationLevel. All known ADBC levels are mapped;
-// only unknown strings produce an error. The underlying database/sql driver
-// decides at BeginTx time whether a given level is actually supported.
+// adbcToSqlIsolationLevel maps ADBC OptionIsolationLevel to sql.IsolationLevel.
+// All known levels are mapped; unknown strings return StatusInvalidArgument.
+// The underlying database/sql driver decides at BeginTx time what is supported.
 func adbcToSqlIsolationLevel(level adbc.OptionIsolationLevel) (sql.IsolationLevel, error) {
 	switch level {
 	case adbc.LevelDefault:
@@ -84,15 +84,12 @@ func adbcToSqlIsolationLevel(level adbc.OptionIsolationLevel) (sql.IsolationLeve
 	}
 }
 
-// beginNewTx starts a new transaction on the dedicated connection, applying
-// the cached isolation level (if any). The resulting *sql.Tx is stored on
-// both the ConnectionImplBase and the LoggingConn so that all subsequent
-// statement execution routes through the transaction.
-//
-// The transaction is started with a context derived from the caller's context
-// via context.WithoutCancel so that it survives across CGO driver-manager
-// calls, each of which creates and cancels its own context. The tx lives
-// until explicitly committed or rolled back via Commit/Rollback.
+// beginNewTx starts a transaction on the dedicated connection with the cached
+// isolation level. The tx context is detached from the caller's cancellation
+// (so it survives across CGO driver-manager calls that cancel per-call contexts)
+// while preserving any deadline so caller timeouts still apply. The cancel
+// function for the deadline context is stored in c.txCancel; call releaseTx to
+// release it when the tx ends.
 func (c *ConnectionImplBase) beginNewTx(ctx context.Context) error {
 	opts := &sql.TxOptions{}
 	if c.isolationLevel != "" && c.isolationLevel != adbc.LevelDefault {
@@ -102,13 +99,37 @@ func (c *ConnectionImplBase) beginNewTx(ctx context.Context) error {
 		}
 		opts.Isolation = level
 	}
-	tx, err := c.Conn.Conn.BeginTx(context.WithoutCancel(ctx), opts)
+
+	txCtx := context.WithoutCancel(ctx)
+	c.txCancel = nil
+	if deadline, ok := ctx.Deadline(); ok {
+		txCtx, c.txCancel = context.WithDeadline(txCtx, deadline)
+	}
+
+	tx, err := c.Conn.Conn.BeginTx(txCtx, opts)
 	if err != nil {
+		if c.txCancel != nil {
+			c.txCancel()
+		}
 		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "BEGIN failed: %v", err)
 	}
 	c.tx = tx
 	c.Conn.Tx = tx
 	return nil
+}
+
+// releaseTx clears the active transaction state and releases the deadline
+// context's cancel function. Must be called after the tx is committed or
+// rolled back, before any subsequent beginNewTx.
+func (c *ConnectionImplBase) releaseTx() {
+	if c.txCancel != nil {
+		c.txCancel()
+		c.txCancel = nil
+	}
+	c.tx = nil
+	if c.Conn != nil {
+		c.Conn.Tx = nil
+	}
 }
 
 // newConnection creates a new ADBC Connection by acquiring a *sql.Conn from the pool.
@@ -176,12 +197,8 @@ func (c *ConnectionImplBase) NewStatement(ctx context.Context) (adbc.StatementWi
 	return newStatement(c)
 }
 
-// SetOption sets a string option on this connection.
-// Handles OptionKeyIsolationLevel by caching the level for the next BeginTx;
-// if a transaction is already active (autocommit was disabled before the
-// isolation level was set), it restarts the transaction with the new level
-// so that subsequent statements use the correct isolation.
-// All other keys are delegated to the embedded driverbase base.
+// SetOption caches OptionKeyIsolationLevel for the next BeginTx. If a tx is
+// already active, commits it and begins a new one with the updated level.
 func (c *ConnectionImplBase) SetOption(ctx context.Context, key, value string) error {
 	switch key {
 	case adbc.OptionKeyIsolationLevel:
@@ -190,18 +207,12 @@ func (c *ConnectionImplBase) SetOption(ctx context.Context, key, value string) e
 			return err
 		}
 		c.isolationLevel = level
-		// If a transaction is already active (e.g. SetAutocommit(false) was
-		// called before SetOption(isolation=...), as sqldriver.BeginTx does),
-		// restart it so the new isolation level takes effect. This is safe
-		// because no user statements have been executed yet when called via
-		// sqldriver.BeginTx (which sets autocommit first, then isolation,
-		// before returning the tx handle to the caller).
 		if c.tx != nil {
-			if err := c.tx.Rollback(); err != nil {
-				return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "ROLLBACK for isolation restart failed: %v", err)
+			tx := c.tx
+			c.releaseTx()
+			if err := tx.Commit(); err != nil {
+				return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "COMMIT for isolation restart failed: %v", err)
 			}
-			c.tx = nil
-			c.Conn.Tx = nil
 			return c.beginNewTx(ctx)
 		}
 		return nil
@@ -210,30 +221,30 @@ func (c *ConnectionImplBase) SetOption(ctx context.Context, key, value string) e
 	}
 }
 
-// GetOption returns a string option value.
-// Handles OptionKeyIsolationLevel by returning the cached level.
+// GetOption returns the cached isolation level (LevelDefault if never set).
 func (c *ConnectionImplBase) GetOption(ctx context.Context, key string) (string, error) {
 	switch key {
 	case adbc.OptionKeyIsolationLevel:
-		return string(c.isolationLevel), nil
+		level := c.isolationLevel
+		if level == "" {
+			level = adbc.LevelDefault
+		}
+		return string(level), nil
 	default:
 		return c.ConnectionImplBase.GetOption(ctx, key)
 	}
 }
 
-// SetAutocommit implements driverbase.AutocommitSetter.
-// Disabling autocommit begins a transaction on the dedicated session
-// connection; enabling it commits any in-flight transaction and lets
-// subsequent statements auto-commit (the database/sql default).
-// The driverbase wrapper updates Base().Autocommit after a successful return.
+// SetAutocommit implements driverbase.AutocommitSetter. Disabling autocommit
+// begins a transaction; enabling it commits any in-flight tx.
 func (c *ConnectionImplBase) SetAutocommit(ctx context.Context, enabled bool) error {
 	if enabled {
 		if c.tx != nil {
-			if err := c.tx.Commit(); err != nil {
+			tx := c.tx
+			c.releaseTx()
+			if err := tx.Commit(); err != nil {
 				return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "COMMIT failed: %v", err)
 			}
-			c.tx = nil
-			c.Conn.Tx = nil
 		}
 		return nil
 	}
@@ -243,43 +254,42 @@ func (c *ConnectionImplBase) SetAutocommit(ctx context.Context, enabled bool) er
 	return nil
 }
 
-// Commit commits the current transaction. After COMMIT a new transaction is
-// immediately begun (chained-transaction semantics) so the next statement
-// continues to run inside a transaction until the caller re-enables autocommit.
-// The driverbase wrapper short-circuits to StatusInvalidState when autocommit
-// is enabled, so this method is only reached when autocommit is disabled.
+// Commit commits the current transaction and begins a new one (chained-tx
+// semantics). The driverbase wrapper short-circuits with StatusInvalidState
+// when autocommit is enabled.
 func (c *ConnectionImplBase) Commit(ctx context.Context) error {
 	if c.tx == nil {
 		return c.Base().ErrorHelper.Errorf(adbc.StatusInvalidState, "no active transaction")
 	}
-	if err := c.tx.Commit(); err != nil {
+	tx := c.tx
+	c.releaseTx()
+	if err := tx.Commit(); err != nil {
 		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "COMMIT failed: %v", err)
 	}
 	return c.beginNewTx(ctx)
 }
 
-// Rollback rolls back the current transaction. Like Commit, it begins a new
-// transaction immediately afterwards (chained-transaction semantics).
-// The driverbase wrapper short-circuits to StatusInvalidState when autocommit
-// is enabled, so this method is only reached when autocommit is disabled.
+// Rollback rolls back the current transaction and begins a new one (chained-tx
+// semantics). The driverbase wrapper short-circuits with StatusInvalidState
+// when autocommit is enabled.
 func (c *ConnectionImplBase) Rollback(ctx context.Context) error {
 	if c.tx == nil {
 		return c.Base().ErrorHelper.Errorf(adbc.StatusInvalidState, "no active transaction")
 	}
-	if err := c.tx.Rollback(); err != nil {
+	tx := c.tx
+	c.releaseTx()
+	if err := tx.Rollback(); err != nil {
 		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "ROLLBACK failed: %v", err)
 	}
 	return c.beginNewTx(ctx)
 }
 
-// Close closes the underlying SQL connection. If a transaction is active,
-// it is rolled back first to avoid leaving the connection in an inconsistent
-// state.
+// Close rolls back any active transaction, then closes the underlying connection.
 func (c *ConnectionImplBase) Close(ctx context.Context) error {
 	if c.tx != nil {
-		_ = c.tx.Rollback()
-		c.tx = nil
-		c.Conn.Tx = nil
+		tx := c.tx
+		c.releaseTx()
+		_ = tx.Rollback()
 	}
 	if err := c.ClearPending(); err != nil {
 		return errors.Join(err, c.Conn.Close())

--- a/sqlwrapper/connection.go
+++ b/sqlwrapper/connection.go
@@ -111,7 +111,7 @@ func (c *ConnectionImplBase) beginNewTx(ctx context.Context) error {
 		if c.txCancel != nil {
 			c.txCancel()
 		}
-		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "BEGIN failed: %v", err)
+		return c.Base().ErrorHelper.WrapInternal(err, "BEGIN failed")
 	}
 	c.tx = tx
 	c.Conn.Tx = tx
@@ -197,8 +197,7 @@ func (c *ConnectionImplBase) NewStatement(ctx context.Context) (adbc.StatementWi
 	return newStatement(c)
 }
 
-// SetOption caches OptionKeyIsolationLevel for the next BeginTx. If a tx is
-// already active, commits it and begins a new one with the updated level.
+// SetOption sets a string option on this connection.
 func (c *ConnectionImplBase) SetOption(ctx context.Context, key, value string) error {
 	switch key {
 	case adbc.OptionKeyIsolationLevel:

--- a/sqlwrapper/logging_connection.go
+++ b/sqlwrapper/logging_connection.go
@@ -29,15 +29,27 @@ import (
 
 type LoggingConn struct {
 	Conn   *sql.Conn
+	Tx     *sql.Tx
 	Logger *slog.Logger
 }
 
 func (tc *LoggingConn) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	if tc.Tx != nil {
+		return tc.Tx.ExecContext(ctx, query, args...)
+	}
 	return tc.Conn.ExecContext(ctx, query, args...)
 }
 
 func (tc *LoggingConn) QueryContext(ctx context.Context, query string, args ...any) (*LoggingRows, error) {
-	rows, err := tc.Conn.QueryContext(ctx, query, args...)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if tc.Tx != nil {
+		rows, err = tc.Tx.QueryContext(ctx, query, args...)
+	} else {
+		rows, err = tc.Conn.QueryContext(ctx, query, args...)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -45,6 +57,9 @@ func (tc *LoggingConn) QueryContext(ctx context.Context, query string, args ...a
 }
 
 func (tc *LoggingConn) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	if tc.Tx != nil {
+		return tc.Tx.QueryRowContext(ctx, query, args...)
+	}
 	return tc.Conn.QueryRowContext(ctx, query, args...)
 }
 
@@ -53,7 +68,15 @@ func (tc *LoggingConn) PingContext(ctx context.Context) error {
 }
 
 func (tc *LoggingConn) PrepareContext(ctx context.Context, query string) (*LoggingStmt, error) {
-	stmt, err := tc.Conn.PrepareContext(ctx, query)
+	var (
+		stmt *sql.Stmt
+		err  error
+	)
+	if tc.Tx != nil {
+		stmt, err = tc.Tx.PrepareContext(ctx, query)
+	} else {
+		stmt, err = tc.Conn.PrepareContext(ctx, query)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/sqlwrapper/logging_connection.go
+++ b/sqlwrapper/logging_connection.go
@@ -24,6 +24,7 @@ package sqlwrapper
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log/slog"
 )
 
@@ -68,20 +69,13 @@ func (tc *LoggingConn) PingContext(ctx context.Context) error {
 }
 
 func (tc *LoggingConn) PrepareContext(ctx context.Context, query string) (*LoggingStmt, error) {
-	var (
-		stmt *sql.Stmt
-		err  error
-	)
-	if tc.Tx != nil {
-		stmt, err = tc.Tx.PrepareContext(ctx, query)
-	} else {
-		stmt, err = tc.Conn.PrepareContext(ctx, query)
-	}
+	stmt, err := tc.Conn.PrepareContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}
 	return &LoggingStmt{
 		Stmt:   stmt,
+		conn:   tc,
 		Logger: tc.Logger,
 	}, nil
 }
@@ -125,15 +119,51 @@ func (lr *LoggingRows) Scan(dest ...any) error {
 
 type LoggingStmt struct {
 	Stmt   *sql.Stmt
+	txStmt *sql.Stmt    // cached tx-scoped wrapper, lazily created via tx.StmtContext
+	txRef  *sql.Tx      // which *sql.Tx txStmt is associated with (nil == no wrapper)
+	conn   *LoggingConn // back-ref to check the current tx at execute time
 	Logger *slog.Logger
 }
 
+// getTxStmt returns the *sql.Stmt to use for execution. When a transaction is
+// active, the conn-scoped Stmt is wrapped via tx.StmtContext so execution
+// participates in the transaction. The wrapper is cached across calls within
+// the same transaction and invalidated (closed + recreated) when the
+// transaction changes (Commit/Rollback/Isolation swap via chained-tx
+// semantics). When no transaction is active, the conn-scoped Stmt is used
+// directly.
+func (ls *LoggingStmt) getTxStmt(ctx context.Context) (*sql.Stmt, error) {
+	if ls.conn == nil || ls.conn.Tx == nil {
+		return ls.Stmt, nil
+	}
+	if ls.txRef == ls.conn.Tx && ls.txStmt != nil {
+		return ls.txStmt, nil
+	}
+	if ls.txStmt != nil {
+		_ = ls.txStmt.Close()
+		ls.txStmt = nil
+		ls.txRef = nil
+	}
+	txStmt := ls.conn.Tx.StmtContext(ctx, ls.Stmt)
+	ls.txStmt = txStmt
+	ls.txRef = ls.conn.Tx
+	return ls.txStmt, nil
+}
+
 func (ls *LoggingStmt) ExecContext(ctx context.Context, args ...any) (sql.Result, error) {
-	return ls.Stmt.ExecContext(ctx, args...)
+	stmt, err := ls.getTxStmt(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return stmt.ExecContext(ctx, args...)
 }
 
 func (ls *LoggingStmt) QueryContext(ctx context.Context, args ...any) (*LoggingRows, error) {
-	rows, err := ls.Stmt.QueryContext(ctx, args...)
+	stmt, err := ls.getTxStmt(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := stmt.QueryContext(ctx, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -141,5 +171,14 @@ func (ls *LoggingStmt) QueryContext(ctx context.Context, args ...any) (*LoggingR
 }
 
 func (ls *LoggingStmt) Close() error {
-	return ls.Stmt.Close()
+	var err error
+	if ls.txStmt != nil {
+		err = errors.Join(err, ls.txStmt.Close())
+		ls.txStmt = nil
+		ls.txRef = nil
+	}
+	if ls.Stmt != nil {
+		err = errors.Join(err, ls.Stmt.Close())
+	}
+	return err
 }

--- a/sqlwrapper/logging_connection.go
+++ b/sqlwrapper/logging_connection.go
@@ -74,9 +74,8 @@ func (tc *LoggingConn) PrepareContext(ctx context.Context, query string) (*Loggi
 		return nil, err
 	}
 	return &LoggingStmt{
-		Stmt:   stmt,
-		conn:   tc,
-		Logger: tc.Logger,
+		Stmt: stmt,
+		conn: tc,
 	}, nil
 }
 
@@ -119,19 +118,11 @@ func (lr *LoggingRows) Scan(dest ...any) error {
 
 type LoggingStmt struct {
 	Stmt   *sql.Stmt
-	txStmt *sql.Stmt    // cached tx-scoped wrapper, lazily created via tx.StmtContext
-	txRef  *sql.Tx      // which *sql.Tx txStmt is associated with (nil == no wrapper)
-	conn   *LoggingConn // back-ref to check the current tx at execute time
-	Logger *slog.Logger
+	txStmt *sql.Stmt
+	txRef  *sql.Tx
+	conn   *LoggingConn
 }
 
-// getTxStmt returns the *sql.Stmt to use for execution. When a transaction is
-// active, the conn-scoped Stmt is wrapped via tx.StmtContext so execution
-// participates in the transaction. The wrapper is cached across calls within
-// the same transaction and invalidated (closed + recreated) when the
-// transaction changes (Commit/Rollback/Isolation swap via chained-tx
-// semantics). When no transaction is active, the conn-scoped Stmt is used
-// directly.
 func (ls *LoggingStmt) getTxStmt(ctx context.Context) (*sql.Stmt, error) {
 	if ls.conn == nil || ls.conn.Tx == nil {
 		return ls.Stmt, nil
@@ -167,7 +158,7 @@ func (ls *LoggingStmt) QueryContext(ctx context.Context, args ...any) (*LoggingR
 	if err != nil {
 		return nil, err
 	}
-	return &LoggingRows{Rows: rows, Logger: ls.Logger}, err
+	return &LoggingRows{Rows: rows, Logger: ls.conn.Logger}, err
 }
 
 func (ls *LoggingStmt) Close() error {

--- a/sqlwrapper/logging_connection_assert.go
+++ b/sqlwrapper/logging_connection_assert.go
@@ -31,10 +31,16 @@ import (
 
 type LoggingConn struct {
 	Conn   *sql.Conn
+	Tx     *sql.Tx
 	Logger *slog.Logger
 }
 
 func (tc *LoggingConn) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	if tc.Tx != nil {
+		rs, err := tc.Tx.ExecContext(ctx, query, args...)
+		tc.Logger.DebugContext(ctx, "LoggingConn.Tx.ExecContext", slog.String("query", query), slog.Any("args", args), slog.Any("err", err))
+		return rs, err
+	}
 	if tc.Conn == nil {
 		return nil, adbc.Error{Code: adbc.StatusInvalidState, Msg: "LoggingConn.ExecContext: nil connection"}
 	}
@@ -44,11 +50,20 @@ func (tc *LoggingConn) ExecContext(ctx context.Context, query string, args ...an
 }
 
 func (tc *LoggingConn) QueryContext(ctx context.Context, query string, args ...any) (*LoggingRows, error) {
-	if tc.Conn == nil {
-		return nil, adbc.Error{Code: adbc.StatusInvalidState, Msg: "LoggingConn.QueryContext: nil connection"}
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if tc.Tx != nil {
+		rows, err = tc.Tx.QueryContext(ctx, query, args...)
+		tc.Logger.DebugContext(ctx, "LoggingConn.Tx.QueryContext", slog.String("query", query), slog.Any("args", args), slog.Any("err", err))
+	} else {
+		if tc.Conn == nil {
+			return nil, adbc.Error{Code: adbc.StatusInvalidState, Msg: "LoggingConn.QueryContext: nil connection"}
+		}
+		rows, err = tc.Conn.QueryContext(ctx, query, args...)
+		tc.Logger.DebugContext(ctx, "LoggingConn.QueryContext", slog.String("query", query), slog.Any("args", args), slog.Any("err", err))
 	}
-	rows, err := tc.Conn.QueryContext(ctx, query, args...)
-	tc.Logger.DebugContext(ctx, "LoggingConn.QueryContext", slog.String("query", query), slog.Any("args", args), slog.Any("err", err))
 	if err != nil {
 		return nil, err
 	}
@@ -56,6 +71,10 @@ func (tc *LoggingConn) QueryContext(ctx context.Context, query string, args ...a
 }
 
 func (tc *LoggingConn) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	if tc.Tx != nil {
+		tc.Logger.DebugContext(ctx, "LoggingConn.Tx.QueryRowContext", slog.String("query", query), slog.Any("args", args))
+		return tc.Tx.QueryRowContext(ctx, query, args...)
+	}
 	if tc.Conn == nil {
 		// We can't construct a sql.Row ourselves
 		panic("LoggingConn.QueryRowContext: nil connection")
@@ -74,11 +93,20 @@ func (tc *LoggingConn) PingContext(ctx context.Context) error {
 }
 
 func (tc *LoggingConn) PrepareContext(ctx context.Context, query string) (*LoggingStmt, error) {
-	if tc.Conn == nil {
-		return nil, adbc.Error{Code: adbc.StatusInvalidState, Msg: "LoggingConn.PrepareContext: nil connection"}
+	var (
+		stmt *sql.Stmt
+		err  error
+	)
+	if tc.Tx != nil {
+		stmt, err = tc.Tx.PrepareContext(ctx, query)
+		tc.Logger.DebugContext(ctx, "LoggingConn.Tx.PrepareContext", slog.String("query", query), slog.Any("err", err))
+	} else {
+		if tc.Conn == nil {
+			return nil, adbc.Error{Code: adbc.StatusInvalidState, Msg: "LoggingConn.PrepareContext: nil connection"}
+		}
+		stmt, err = tc.Conn.PrepareContext(ctx, query)
+		tc.Logger.DebugContext(ctx, "LoggingConn.PrepareContext", slog.String("query", query), slog.Any("err", err))
 	}
-	stmt, err := tc.Conn.PrepareContext(ctx, query)
-	tc.Logger.DebugContext(ctx, "LoggingConn.PrepareContext", slog.String("query", query), slog.Any("err", err))
 	if err != nil {
 		return nil, err
 	}

--- a/sqlwrapper/logging_connection_assert.go
+++ b/sqlwrapper/logging_connection_assert.go
@@ -103,9 +103,8 @@ func (tc *LoggingConn) PrepareContext(ctx context.Context, query string) (*Loggi
 		return nil, err
 	}
 	return &LoggingStmt{
-		Stmt:   stmt,
-		conn:   tc,
-		Logger: tc.Logger,
+		Stmt: stmt,
+		conn: tc,
 	}, nil
 }
 
@@ -202,35 +201,27 @@ func (lr *LoggingRows) Scan(dest ...any) error {
 
 type LoggingStmt struct {
 	Stmt   *sql.Stmt
-	txStmt *sql.Stmt    // cached tx-scoped wrapper, lazily created via tx.StmtContext
-	txRef  *sql.Tx      // which *sql.Tx txStmt is associated with (nil == no wrapper)
-	conn   *LoggingConn // back-ref to check the current tx at execute time
-	Logger *slog.Logger
+	txStmt *sql.Stmt
+	txRef  *sql.Tx
+	conn   *LoggingConn
 }
 
-// getTxStmt returns the *sql.Stmt to use for execution. When a transaction is
-// active, the conn-scoped Stmt is wrapped via tx.StmtContext so execution
-// participates in the transaction. The wrapper is cached across calls within
-// the same transaction and invalidated (closed + recreated) when the
-// transaction changes (Commit/Rollback/Isolation swap via chained-tx
-// semantics). When no transaction is active, the conn-scoped Stmt is used
-// directly.
 func (ls *LoggingStmt) getTxStmt(ctx context.Context) (*sql.Stmt, error) {
 	if ls.conn == nil || ls.conn.Tx == nil {
-		ls.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: no active tx, using conn-scoped stmt")
+		ls.conn.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: no active tx, using conn-scoped stmt")
 		return ls.Stmt, nil
 	}
 	if ls.txRef == ls.conn.Tx && ls.txStmt != nil {
-		ls.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: cache hit (same tx)")
+		ls.conn.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: cache hit (same tx)")
 		return ls.txStmt, nil
 	}
 	if ls.txStmt != nil {
-		ls.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: cache miss (tx changed), closing old wrapper")
+		ls.conn.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: cache miss (tx changed), closing old wrapper")
 		_ = ls.txStmt.Close()
 		ls.txStmt = nil
 		ls.txRef = nil
 	}
-	ls.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: creating tx.StmtContext wrapper")
+	ls.conn.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: creating tx.StmtContext wrapper")
 	txStmt := ls.conn.Tx.StmtContext(ctx, ls.Stmt)
 	ls.txStmt = txStmt
 	ls.txRef = ls.conn.Tx
@@ -246,7 +237,7 @@ func (ls *LoggingStmt) ExecContext(ctx context.Context, args ...any) (sql.Result
 		return nil, err
 	}
 	rs, err := stmt.ExecContext(ctx, args...)
-	ls.Logger.DebugContext(ctx, "LoggingStmt.ExecContext", slog.Any("args", args), slog.Any("err", err))
+	ls.conn.Logger.DebugContext(ctx, "LoggingStmt.ExecContext", slog.Any("args", args), slog.Any("err", err))
 	return rs, err
 }
 
@@ -259,21 +250,21 @@ func (ls *LoggingStmt) QueryContext(ctx context.Context, args ...any) (*LoggingR
 		return nil, err
 	}
 	rows, err := stmt.QueryContext(ctx, args...)
-	ls.Logger.DebugContext(ctx, "LoggingStmt.QueryContext", slog.Any("args", args), slog.Any("err", err))
-	return &LoggingRows{Rows: rows, Logger: ls.Logger}, err
+	ls.conn.Logger.DebugContext(ctx, "LoggingStmt.QueryContext", slog.Any("args", args), slog.Any("err", err))
+	return &LoggingRows{Rows: rows, Logger: ls.conn.Logger}, err
 }
 
 func (ls *LoggingStmt) Close() error {
 	var err error
 	if ls.txStmt != nil {
 		err = errors.Join(err, ls.txStmt.Close())
-		ls.Logger.Debug("LoggingStmt.Close txStmt", slog.Any("err", err))
+		ls.conn.Logger.Debug("LoggingStmt.Close txStmt", slog.Any("err", err))
 		ls.txStmt = nil
 		ls.txRef = nil
 	}
 	if ls.Stmt != nil {
 		err = errors.Join(err, ls.Stmt.Close())
-		ls.Logger.Debug("LoggingStmt.Close", slog.Any("err", err))
+		ls.conn.Logger.Debug("LoggingStmt.Close", slog.Any("err", err))
 		ls.Stmt = nil
 	}
 	return err

--- a/sqlwrapper/logging_connection_assert.go
+++ b/sqlwrapper/logging_connection_assert.go
@@ -24,6 +24,7 @@ package sqlwrapper
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log/slog"
 
 	"github.com/apache/arrow-adbc/go/adbc"
@@ -93,25 +94,17 @@ func (tc *LoggingConn) PingContext(ctx context.Context) error {
 }
 
 func (tc *LoggingConn) PrepareContext(ctx context.Context, query string) (*LoggingStmt, error) {
-	var (
-		stmt *sql.Stmt
-		err  error
-	)
-	if tc.Tx != nil {
-		stmt, err = tc.Tx.PrepareContext(ctx, query)
-		tc.Logger.DebugContext(ctx, "LoggingConn.Tx.PrepareContext", slog.String("query", query), slog.Any("err", err))
-	} else {
-		if tc.Conn == nil {
-			return nil, adbc.Error{Code: adbc.StatusInvalidState, Msg: "LoggingConn.PrepareContext: nil connection"}
-		}
-		stmt, err = tc.Conn.PrepareContext(ctx, query)
-		tc.Logger.DebugContext(ctx, "LoggingConn.PrepareContext", slog.String("query", query), slog.Any("err", err))
+	if tc.Conn == nil {
+		return nil, adbc.Error{Code: adbc.StatusInvalidState, Msg: "LoggingConn.PrepareContext: nil connection"}
 	}
+	stmt, err := tc.Conn.PrepareContext(ctx, query)
+	tc.Logger.DebugContext(ctx, "LoggingConn.PrepareContext", slog.String("query", query), slog.Any("err", err))
 	if err != nil {
 		return nil, err
 	}
 	return &LoggingStmt{
 		Stmt:   stmt,
+		conn:   tc,
 		Logger: tc.Logger,
 	}, nil
 }
@@ -209,14 +202,50 @@ func (lr *LoggingRows) Scan(dest ...any) error {
 
 type LoggingStmt struct {
 	Stmt   *sql.Stmt
+	txStmt *sql.Stmt    // cached tx-scoped wrapper, lazily created via tx.StmtContext
+	txRef  *sql.Tx      // which *sql.Tx txStmt is associated with (nil == no wrapper)
+	conn   *LoggingConn // back-ref to check the current tx at execute time
 	Logger *slog.Logger
+}
+
+// getTxStmt returns the *sql.Stmt to use for execution. When a transaction is
+// active, the conn-scoped Stmt is wrapped via tx.StmtContext so execution
+// participates in the transaction. The wrapper is cached across calls within
+// the same transaction and invalidated (closed + recreated) when the
+// transaction changes (Commit/Rollback/Isolation swap via chained-tx
+// semantics). When no transaction is active, the conn-scoped Stmt is used
+// directly.
+func (ls *LoggingStmt) getTxStmt(ctx context.Context) (*sql.Stmt, error) {
+	if ls.conn == nil || ls.conn.Tx == nil {
+		ls.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: no active tx, using conn-scoped stmt")
+		return ls.Stmt, nil
+	}
+	if ls.txRef == ls.conn.Tx && ls.txStmt != nil {
+		ls.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: cache hit (same tx)")
+		return ls.txStmt, nil
+	}
+	if ls.txStmt != nil {
+		ls.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: cache miss (tx changed), closing old wrapper")
+		_ = ls.txStmt.Close()
+		ls.txStmt = nil
+		ls.txRef = nil
+	}
+	ls.Logger.DebugContext(ctx, "LoggingStmt.getTxStmt: creating tx.StmtContext wrapper")
+	txStmt := ls.conn.Tx.StmtContext(ctx, ls.Stmt)
+	ls.txStmt = txStmt
+	ls.txRef = ls.conn.Tx
+	return ls.txStmt, nil
 }
 
 func (ls *LoggingStmt) ExecContext(ctx context.Context, args ...any) (sql.Result, error) {
 	if ls.Stmt == nil {
 		return nil, adbc.Error{Code: adbc.StatusInvalidState, Msg: "LoggingStmt.ExecContext: nil statement"}
 	}
-	rs, err := ls.Stmt.ExecContext(ctx, args...)
+	stmt, err := ls.getTxStmt(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rs, err := stmt.ExecContext(ctx, args...)
 	ls.Logger.DebugContext(ctx, "LoggingStmt.ExecContext", slog.Any("args", args), slog.Any("err", err))
 	return rs, err
 }
@@ -225,19 +254,27 @@ func (ls *LoggingStmt) QueryContext(ctx context.Context, args ...any) (*LoggingR
 	if ls.Stmt == nil {
 		return nil, adbc.Error{Code: adbc.StatusInvalidState, Msg: "LoggingStmt.QueryContext: nil statement"}
 	}
-	rows, err := ls.Stmt.QueryContext(ctx, args...)
+	stmt, err := ls.getTxStmt(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := stmt.QueryContext(ctx, args...)
 	ls.Logger.DebugContext(ctx, "LoggingStmt.QueryContext", slog.Any("args", args), slog.Any("err", err))
 	return &LoggingRows{Rows: rows, Logger: ls.Logger}, err
 }
 
 func (ls *LoggingStmt) Close() error {
-	if ls.Stmt != nil {
-		defer func() {
-			ls.Stmt = nil
-		}()
-		err := ls.Stmt.Close()
-		ls.Logger.Debug("LoggingStmt.Close", slog.Any("err", err))
-		return err
+	var err error
+	if ls.txStmt != nil {
+		err = errors.Join(err, ls.txStmt.Close())
+		ls.Logger.Debug("LoggingStmt.Close txStmt", slog.Any("err", err))
+		ls.txStmt = nil
+		ls.txRef = nil
 	}
-	return nil
+	if ls.Stmt != nil {
+		err = errors.Join(err, ls.Stmt.Close())
+		ls.Logger.Debug("LoggingStmt.Close", slog.Any("err", err))
+		ls.Stmt = nil
+	}
+	return err
 }


### PR DESCRIPTION
Closes https://github.com/adbc-drivers/driverbase-go/issues/28

## Summary

Replaces the stub `Commit`/`Rollback` implementations (which returned `StatusNotImplemented`) with real `database/sql` transaction support, giving downstream drivers working transaction and isolation level management out of the box.

## Breaking Changes

1. **`Commit`/`Rollback` error codes changed** — Previously always returned `StatusNotImplemented`. Now returns `StatusInvalidState` (no active tx) or `StatusInternal` (SQL failure). Code matching on the old error message or `StatusNotImplemented` needs updating.

2. **`LoggingConn` has a new exported field `Tx *sql.Tx`** — Named-field construction (`&LoggingConn{Conn: c, Logger: l}`) is unaffected (`Tx` defaults to nil). Positional construction will fail to compile.

3. **`Close()` now rolls back active transactions** — Uncommitted work is explicitly discarded rather than relying on server-side session cleanup.

4. **`SetOption`/`GetOption` intercept `OptionKeyIsolationLevel`** — Downstream drivers with custom isolation level handling in their `SetOption` override may need to adjust delegation order.