### PR TITLE
fix(ffitemplate): export FooBarInit and FoobarInit

### DIFF
--- a/ffitemplate/_tmpl/driver.go.tmpl
+++ b/ffitemplate/_tmpl/driver.go.tmpl
@@ -1863,8 +1863,8 @@ func {{.Prefix}}StatementExecutePartitions(stmt *C.struct_AdbcStatement, schema 
 	return C.ADBC_STATUS_OK
 }
 
-//export AdbcDriver{{.Prefix}}Init
-func AdbcDriver{{.Prefix}}Init(version C.int, rawDriver *C.void, err *C.struct_AdbcError) C.AdbcStatusCode {
+//export AdbcDriver{{.PrefixNoCamel}}Init
+func AdbcDriver{{.PrefixNoCamel}}Init(version C.int, rawDriver *C.void, err *C.struct_AdbcError) C.AdbcStatusCode {
 	driver := (*C.struct_AdbcDriver)(unsafe.Pointer(rawDriver))
 
 	switch version {
@@ -1947,5 +1947,13 @@ func AdbcDriver{{.Prefix}}Init(version C.int, rawDriver *C.void, err *C.struct_A
 
 	return C.ADBC_STATUS_OK
 }
+
+{{if ne .Prefix .PrefixNoCamel}}
+//export AdbcDriver{{.Prefix}}Init
+func AdbcDriver{{.Prefix}}Init(version C.int, rawDriver *C.void, err *C.struct_AdbcError) C.AdbcStatusCode {
+	// Backwards compatibility alias
+	return AdbcDriver{{.PrefixNoCamel}}Init(version, rawDriver, err)
+}
+{{end}}
 
 func main() {}

--- a/ffitemplate/main.go
+++ b/ffitemplate/main.go
@@ -84,9 +84,11 @@ type tmplData struct {
 	Driver        string
 	DriverImport  string
 	DriverPackage string
+	// MySQL, mysql, MYSQL, Mysql
 	Prefix        string
 	PrefixLower   string
 	PrefixUpper   string
+	PrefixNoCamel string
 }
 
 var fileList = []string{
@@ -141,6 +143,7 @@ func main() {
 		Prefix:        *prefix,
 		PrefixLower:   strings.ToLower(*prefix),
 		PrefixUpper:   strings.ToUpper(*prefix),
+		PrefixNoCamel: (*prefix)[0:1] + strings.ToLower((*prefix)[1:]),
 	}, specs)
 }
 


### PR DESCRIPTION
The latter is correct but we were only exporting the former. Keep both for compatibility.
