### PR TITLE
fix(driverbase/arrowext): don't use coroutines due to CGo issues

### DIFF
--- a/driverbase/arrowext/dict_utils.go
+++ b/driverbase/arrowext/dict_utils.go
@@ -17,6 +17,7 @@ package arrowext
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/adbc-drivers/driverbase-go/driverbase"
 	"github.com/apache/arrow-go/v18/arrow"
@@ -95,22 +96,117 @@ func DictDecodeRecordReader(mem memory.Allocator, errHelper *driverbase.ErrorHel
 	}
 
 	ctx := compute.WithAllocator(context.Background(), mem)
-	return array.ReaderFromIter(schema, func(yield func(arrow.RecordBatch, error) bool) {
-		defer reader.Release()
-		for reader.Next() {
-			batch := reader.RecordBatch()
-			decoded, err := DictDecodeRecordBatch(ctx, schema, batch)
-			if err != nil {
-				err = errHelper.WrapInternal(err, "decode dictionary batch")
-				yield(nil, err)
-				return
-			}
-			if !yield(decoded, nil) {
-				return
-			}
+	// Do not use array.ReaderFromIter here. It uses iter.Pull, which can panic
+	// when the underlying reader calls into Go from cgo. See
+	// https://github.com/golang/go/issues/67499.
+
+	// You would see something like the following:
+
+	// coro: got thread 0x2550e0bc5808, want 0x2550e0bc4008
+	// coro: got lock internal 0, want 2
+	// coro: got lock external 0, want 0
+	// fatal error: coro: OS thread locking must match locking at coroutine creation
+	//
+	// runtime stack:
+	// runtime.throw({0x7f0f8e9a84fb?, 0x7f0f8d180337?})
+	// 	/opt/hostedtoolcache/go/1.26.4/x64/src/runtime/panic.go:1229 +0x4a fp=0x7f0f3effdda8 sp=0x7f0f3effdd78 pc=0x7f0f8d1b3a4a
+	// runtime.coroswitch_m(0x2550e0dac3c0?)
+	// 	/opt/hostedtoolcache/go/1.26.4/x64/src/runtime/coro.go:128 +0x54e fp=0x7f0f3effde38 sp=0x7f0f3effdda8 pc=0x7f0f8d147fee
+	// runtime.mcall()
+	// 	/opt/hostedtoolcache/go/1.26.4/x64/src/runtime/asm_amd64.s:496 +0x57 fp=0x7f0f3effde50 sp=0x7f0f3effde38 pc=0x7f0f8d1b9a17
+	//
+	// goroutine 2928 gp=0x2550e0dac3c0 m=4 mp=0x2550e0bc5808 [running]:
+	// runtime.coroswitch(0x7f0f8d447cc2?)
+	// 	/opt/hostedtoolcache/go/1.26.4/x64/src/runtime/coro.go:94 +0x47 fp=0x2550e0dd5de8 sp=0x2550e0dd5dc8 pc=0x7f0f8d1b0c87
+	// iter.Pull2[...].func2()
+	// 	/opt/hostedtoolcache/go/1.26.4/x64/src/iter/iter.go:434 +0x68 fp=0x2550e0dd5e28 sp=0x2550e0dd5de8 pc=0x7f0f8d476828
+	// github.com/apache/arrow-go/v18/arrow/array.(*iterReader).Next(0x2550e0e162c0)
+	// 	/home/runner/go/pkg/mod/github.com/apache/arrow-go/v18@v18.7.0/arrow/array/record.go:543 +0x3d fp=0x2550e0dd5e40 sp=0x2550e0dd5e28 pc=0x7f0f8d44989d
+
+	decoded := &dictDecodeRecordReader{
+		ctx:       ctx,
+		schema:    schema,
+		errHelper: errHelper,
+		reader:    reader,
+	}
+	decoded.refCount.Add(1)
+	return decoded
+}
+
+type dictDecodeRecordReader struct {
+	refCount atomic.Int64
+
+	ctx       context.Context
+	schema    *arrow.Schema
+	errHelper *driverbase.ErrorHelper
+	reader    array.RecordReader
+	current   arrow.RecordBatch
+	err       error
+}
+
+var _ array.RecordReader = (*dictDecodeRecordReader)(nil)
+
+func (r *dictDecodeRecordReader) Retain() {
+	r.refCount.Add(1)
+}
+
+func (r *dictDecodeRecordReader) Release() {
+	newCount := r.refCount.Add(-1)
+	if newCount == 0 {
+		if r.current != nil {
+			r.current.Release()
+			r.current = nil
 		}
-		if err := reader.Err(); err != nil {
-			yield(nil, err)
-		}
-	})
+		r.releaseReader()
+	}
+	driverbase.DebugAssert(newCount >= 0, "refCount went negative in dictDecodeRecordReader")
+}
+
+func (r *dictDecodeRecordReader) Schema() *arrow.Schema {
+	return r.schema
+}
+
+func (r *dictDecodeRecordReader) Next() bool {
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
+	if r.reader == nil {
+		return false
+	}
+
+	if !r.reader.Next() {
+		r.err = r.reader.Err()
+		r.releaseReader()
+		return false
+	}
+
+	decoded, err := DictDecodeRecordBatch(r.ctx, r.schema, r.reader.RecordBatch())
+	if err != nil {
+		r.err = r.errHelper.WrapInternal(err, "decode dictionary batch")
+		r.releaseReader()
+		return false
+	}
+	r.current = decoded
+	return true
+}
+
+func (r *dictDecodeRecordReader) RecordBatch() arrow.RecordBatch {
+	return r.current
+}
+
+// Deprecated: Use [dictDecodeRecordReader.RecordBatch] instead.
+func (r *dictDecodeRecordReader) Record() arrow.RecordBatch {
+	return r.RecordBatch()
+}
+
+func (r *dictDecodeRecordReader) Err() error {
+	return r.err
+}
+
+func (r *dictDecodeRecordReader) releaseReader() {
+	if r.reader != nil {
+		r.reader.Release()
+		r.reader = nil
+	}
 }

--- a/driverbase/arrowext/dict_utils_test.go
+++ b/driverbase/arrowext/dict_utils_test.go
@@ -15,6 +15,7 @@
 package arrowext_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/adbc-drivers/driverbase-go/driverbase"
@@ -25,6 +26,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type failingRecordReader struct {
+	schema   *arrow.Schema
+	err      error
+	refCount int
+}
+
+func (r *failingRecordReader) Retain()                        { r.refCount++ }
+func (r *failingRecordReader) Release()                       { r.refCount-- }
+func (r *failingRecordReader) Schema() *arrow.Schema          { return r.schema }
+func (r *failingRecordReader) Next() bool                     { return false }
+func (r *failingRecordReader) Record() arrow.RecordBatch      { return nil }
+func (r *failingRecordReader) RecordBatch() arrow.RecordBatch { return nil }
+func (r *failingRecordReader) Err() error                     { return r.err }
 
 func TestDictDecodeSchema(t *testing.T) {
 	var schema *arrow.Schema
@@ -91,4 +106,30 @@ func TestDictDecodeRecordReader(t *testing.T) {
 
 	assert.False(t, decoded.Next())
 	require.NoError(t, decoded.Err())
+}
+
+func TestDictDecodeRecordReaderPropagatesError(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	expected := errors.New("reader failed")
+	reader := &failingRecordReader{
+		schema: arrow.NewSchema([]arrow.Field{{
+			Name: "value",
+			Type: &arrow.DictionaryType{
+				IndexType: arrow.PrimitiveTypes.Int32,
+				ValueType: arrow.BinaryTypes.String,
+			},
+		}}, nil),
+		err:      expected,
+		refCount: 1,
+	}
+
+	decoded := arrowext.DictDecodeRecordReader(mem, &driverbase.ErrorHelper{DriverName: "test"}, reader)
+	reader.Release()
+	defer decoded.Release()
+
+	assert.False(t, decoded.Next())
+	require.ErrorIs(t, decoded.Err(), expected)
+	assert.Equal(t, 0, reader.refCount)
 }


### PR DESCRIPTION
Work around https://github.com/golang/go/issues/67499.

Generated-by: GPT 5.6 Sol <codex@openai.com>